### PR TITLE
Add waveform visualization to WASM demo

### DIFF
--- a/deepfilternet3/wasm_worker_sharedarraybuffer/index.html
+++ b/deepfilternet3/wasm_worker_sharedarraybuffer/index.html
@@ -23,5 +23,11 @@
     <label for="gain">Volume: </label>
     <input id="gain" type="range" min="0" max="40" />
 
+    <h2>Raw</h2>
+    <canvas id="raw" width="600" height="100"></canvas>
+
+    <h2>Denoised</h2>
+    <canvas id="denoised" width="600" height="100"></canvas>
+
   </body>
 </html>


### PR DESCRIPTION
## Summary
- visualize the microphone audio before/after denoising in the WASM demo
- connect AnalyserNode instances to the processing graph

## 課題点と直接的な原因
- ノイズ除去前後の音声波形が確認できなかった
- 可視化用ノードやキャンバスが存在しなかった

## 対策
- index.html に Raw/Denoised 用の `<canvas>` を追加
- script.js で `AnalyserNode` を利用し波形描画処理を実装